### PR TITLE
feat: add Engine Start and Engine Stop service actions

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -25,6 +25,10 @@ from .audi_account import (
     SERVICE_START_AUXILIARY_HEATING_SCHEMA,
     SERVICE_START_CLIMATE_CONTROL,
     SERVICE_START_CLIMATE_CONTROL_SCHEMA,
+    SERVICE_START_ENGINE,
+    SERVICE_START_ENGINE_SCHEMA,
+    SERVICE_STOP_ENGINE,
+    SERVICE_STOP_ENGINE_SCHEMA,
 )
 from .const import (
     CONF_API_LEVEL,
@@ -198,6 +202,20 @@ def _async_register_services(hass: HomeAssistant) -> None:
         vin, account = result
         await account.set_target_soc(vin, service)
 
+    async def _handle_start_engine(service: ServiceCall) -> None:
+        result = _resolve_service_call(hass, service)
+        if result is None:
+            return
+        vin, account = result
+        await account.start_engine(vin)
+
+    async def _handle_stop_engine(service: ServiceCall) -> None:
+        result = _resolve_service_call(hass, service)
+        if result is None:
+            return
+        vin, account = result
+        await account.stop_engine(vin)
+
     if not hass.services.has_service(DOMAIN, SERVICE_REFRESH_CLOUD_DATA):
         hass.services.async_register(
             DOMAIN, SERVICE_REFRESH_CLOUD_DATA, _handle_refresh_cloud_data
@@ -236,6 +254,20 @@ def _async_register_services(hass: HomeAssistant) -> None:
             SERVICE_SET_TARGET_SOC,
             _handle_set_target_soc,
             schema=SERVICE_SET_TARGET_SOC_SCHEMA,
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_START_ENGINE):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_START_ENGINE,
+            _handle_start_engine,
+            schema=SERVICE_START_ENGINE_SCHEMA,
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_STOP_ENGINE):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_STOP_ENGINE,
+            _handle_stop_engine,
+            schema=SERVICE_STOP_ENGINE_SCHEMA,
         )
 
 
@@ -316,6 +348,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             SERVICE_START_CLIMATE_CONTROL,
             SERVICE_START_AUXILIARY_HEATING,
             SERVICE_SET_TARGET_SOC,
+            SERVICE_START_ENGINE,
+            SERVICE_STOP_ENGINE,
         ):
             if hass.services.has_service(DOMAIN, service):
                 hass.services.async_remove(DOMAIN, service)

--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -88,6 +88,16 @@ SERVICE_SET_TARGET_SOC_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_START_ENGINE = "start_engine"
+SERVICE_START_ENGINE_SCHEMA = vol.Schema(
+    {vol.Required(CONF_DEVICE_ID): cv.string}
+)
+
+SERVICE_STOP_ENGINE = "stop_engine"
+SERVICE_STOP_ENGINE_SCHEMA = vol.Schema(
+    {vol.Required(CONF_DEVICE_ID): cv.string}
+)
+
 SERVICE_REFRESH_CLOUD_DATA = "refresh_cloud_data"
 
 
@@ -213,6 +223,14 @@ class AudiAccount(AudiConnectObserver):
             service.data.get(CONF_TARGET_SOC),
         )
 
+    async def start_engine(self, vin: str) -> None:
+        """Start engine for a vehicle by VIN."""
+        await self.connection.start_engine(vin.lower())
+
+    async def stop_engine(self, vin: str) -> None:
+        """Stop engine for a vehicle by VIN."""
+        await self.connection.stop_engine(vin.lower())
+
     async def handle_notification(self, vin: str, action: str) -> None:
         if self.config_entry.options.get(CONF_REFRESH_AFTER_ACTION, False):
             await self._refresh_vehicle_data(vin)
@@ -263,4 +281,8 @@ __all__ = [
     "SERVICE_START_AUXILIARY_HEATING_SCHEMA",
     "SERVICE_START_CLIMATE_CONTROL",
     "SERVICE_START_CLIMATE_CONTROL_SCHEMA",
+    "SERVICE_START_ENGINE",
+    "SERVICE_START_ENGINE_SCHEMA",
+    "SERVICE_STOP_ENGINE",
+    "SERVICE_STOP_ENGINE_SCHEMA",
 ]

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -25,6 +25,7 @@ ACTION_CLIMATISATION = "climatisation"
 ACTION_CHARGER = "charger"
 ACTION_WINDOW_HEATING = "window_heating"
 ACTION_PRE_HEATER = "pre_heater"
+ACTION_ENGINE = "engine"
 
 
 class AudiConnectObserver(ABC):
@@ -528,6 +529,72 @@ class AudiConnectAccount:
             except Exception as ex:
                 _LOGGER.warning(
                     "Cloud refresh failed after pre-heater for %s: %s", vin, ex
+                )
+
+    async def start_engine(self, vin: str):
+        if not self._loggedin:
+            await self.login()
+
+        if not self._loggedin:
+            return False
+
+        try:
+            _LOGGER.debug(
+                "Sending command to start engine for vehicle %s", vin
+            )
+
+            await self._audi_service.start_engine(vin)
+
+            _LOGGER.debug(
+                "Successfully started engine of vehicle %s", vin
+            )
+
+            return True
+
+        except Exception as exception:
+            log_exception(
+                exception,
+                "Unable to start engine of vehicle {vin}".format(vin=vin),
+            )
+        finally:
+            try:
+                await self.notify(vin, ACTION_ENGINE)
+            except Exception as ex:
+                _LOGGER.warning(
+                    "Cloud refresh failed after engine start for %s: %s", vin, ex
+                )
+
+    async def stop_engine(self, vin: str):
+        if not self._loggedin:
+            await self.login()
+
+        if not self._loggedin:
+            return False
+
+        try:
+            _LOGGER.debug(
+                "Sending command to stop engine for vehicle %s", vin
+            )
+
+            await self._audi_service.stop_engine(vin)
+
+            _LOGGER.debug(
+                "Successfully stopped engine of vehicle %s", vin
+            )
+
+            return True
+
+        except Exception as exception:
+            log_exception(
+                exception,
+                "Unable to stop engine of vehicle {vin}".format(vin=vin),
+            )
+        finally:
+            try:
+                await self.notify(vin, ACTION_ENGINE)
+            except Exception as ex:
+                _LOGGER.warning(
+                    "Cloud refresh failed after engine stop for %s: %s", vin, ex
                 )
 
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -877,6 +877,68 @@ class AudiService:
 
         await self.check_bff_request_succeeded(vin, res["data"]["requestID"])
 
+    async def start_engine(self, vin: str) -> None:
+        if self._spin is None:
+            raise Exception("S-PIN is required to start the engine")
+
+        headers = {
+            "Accept": "application/json",
+            "Accept-charset": "utf-8",
+            "Authorization": "Bearer " + self._bearer_token_json["access_token"],
+            "User-Agent": AudiAPI.HDR_USER_AGENT,
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept-encoding": "gzip",
+        }
+
+        # Step 1: Obtain userPromptProof
+        proof_res = await self._api.request(
+            "PUT",
+            self.__get_cariad_url(
+                "/vehicle/v1/engine/{vin}/userpromptproof", vin=vin.upper()
+            ),
+            headers=headers,
+            data=json.dumps({"spin": self._spin}),
+        )
+        user_prompt_proof = proof_res["userPromptProof"]
+
+        # Step 2: Submit start request
+        res = await self._api.request(
+            "POST",
+            self.__get_cariad_url(
+                "/vehicle/v1/engine/{vin}/start", vin=vin.upper()
+            ),
+            headers=headers,
+            data=json.dumps(
+                {
+                    "securedActivationData": user_prompt_proof,
+                    "spin": self._spin,
+                }
+            ),
+        )
+
+        await self.check_bff_request_succeeded(vin, res["data"]["requestID"])
+
+    async def stop_engine(self, vin: str) -> None:
+        headers = {
+            "Accept": "application/json",
+            "Accept-charset": "utf-8",
+            "Authorization": "Bearer " + self._bearer_token_json["access_token"],
+            "User-Agent": AudiAPI.HDR_USER_AGENT,
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept-encoding": "gzip",
+        }
+
+        res = await self._api.request(
+            "POST",
+            self.__get_cariad_url(
+                "/vehicle/v1/engine/{vin}/stop", vin=vin.upper()
+            ),
+            headers=headers,
+            data=None,
+        )
+
+        await self.check_bff_request_succeeded(vin, res["data"]["requestID"])
+
     async def check_bff_request_succeeded(self, vin: str, request_id: str):
         headers = {
             "Accept": "application/json",

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -109,3 +109,19 @@ set_target_soc:
           max: 100
           step: 5
           unit_of_measurement: "%"
+
+start_engine:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: audiconnect
+
+stop_engine:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: audiconnect

--- a/custom_components/audiconnect/strings.json
+++ b/custom_components/audiconnect/strings.json
@@ -184,6 +184,26 @@
           "description": "Target state of charge percentage (20-100%)."
         }
       }
+    },
+    "start_engine": {
+      "name": "Start Engine",
+      "description": "Remotely start the vehicle engine. Requires the S-PIN to be set in the configuration.",
+      "fields": {
+        "device_id": {
+          "name": "Vehicle",
+          "description": "The Audi vehicle to start the engine on."
+        }
+      }
+    },
+    "stop_engine": {
+      "name": "Stop Engine",
+      "description": "Remotely stop the vehicle engine.",
+      "fields": {
+        "device_id": {
+          "name": "Vehicle",
+          "description": "The Audi vehicle to stop the engine on."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Engine Start uses a two-step authenticated flow:
1. PUT to /engine/{VIN}/userpromptproof with S-PIN to obtain a proof token
2. POST to /engine/{VIN}/start with securedActivationData and S-PIN

Engine Stop is a single POST to /engine/{VIN}/stop with no body.

Both actions use the device dropdown for vehicle selection and the existing requestID success-checking logic (check_bff_request_succeeded).